### PR TITLE
Add ignore default args option to roslaunch-check

### DIFF
--- a/tools/roslaunch/cmake/roslaunch-extras.cmake.em
+++ b/tools/roslaunch/cmake/roslaunch-extras.cmake.em
@@ -20,12 +20,14 @@ set(roslaunch_check_script ${roslaunch_DIR}/../scripts/roslaunch-check)
 # :param USE_TEST_DEPENDENCIES: beside run dependencies also consider test
 #   dependencies when checking if all dependencies of a launch file are present
 # :type USE_TEST_DEPENDENCIES: option
+# :param IGNORE_DEFAULT_ARGS: ignore the errors for default values not being set in <arg> tags
+# :type IGNORE_DEFAULT_ARGS: option
 # :param ARGV: arbitrary arguments in the form 'key=value'
 #   which will be set as environment variables
 # :type ARGV: string
 #
 function(roslaunch_add_file_check path)
-  cmake_parse_arguments(_roslaunch "USE_TEST_DEPENDENCIES" "" "DEPENDENCIES" ${ARGN})
+  cmake_parse_arguments(_roslaunch "USE_TEST_DEPENDENCIES;IGNORE_DEFAULT_ARGS" "" "DEPENDENCIES" ${ARGN})
   if(IS_ABSOLUTE ${path})
     set(abspath ${path})
   else()
@@ -56,9 +58,13 @@ function(roslaunch_add_file_check path)
   set(output_file_name "roslaunch-check_${testname}.xml")
   string(REPLACE ";" " " _roslaunch_UNPARSED_ARGUMENTS "${_roslaunch_UNPARSED_ARGUMENTS}")
   set(use_test_dependencies "")
+  set(ignore_default_args "")
   if(${_roslaunch_USE_TEST_DEPENDENCIES})
     set(use_test_dependencies " -t")
   endif()
-  set(cmd ${cmd} "${roslaunch_check_script} -o '${output_path}/${output_file_name}'${use_test_dependencies} '${abspath}' ${_roslaunch_UNPARSED_ARGUMENTS}")
+  if(${_roslaunch_IGNORE_DEFAULT_ARGS})
+    set(ignore_default_args " -i")
+  endif()
+  set(cmd ${cmd} "${roslaunch_check_script} -o '${output_path}/${output_file_name}'${use_test_dependencies}${ignore_default_args} '${abspath}' ${_roslaunch_UNPARSED_ARGUMENTS}")
   catkin_run_tests_target("roslaunch-check" ${testname} "${output_file_name}" COMMAND ${cmd} DEPENDENCIES ${_roslaunch_DEPENDENCIES})
 endfunction()

--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -74,7 +74,7 @@ if __name__ == '__main__':
     parser.add_option("-t", "--use-test-depends",
                       action="store_true", dest="test_depends", default=False,
                       help="Assuming packages listed in test_depends are also installed")
-    parser.add_option("--ignore-default-args",
+    parser.add_option("-i", "--ignore-default-args",
                       action="store_true", dest="ignore_default_args", default=False,
                       help="Ignore check for default value of <arg> parameters")
 

--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -43,14 +43,9 @@ import rosunit
 
 def check_roslaunch_file(roslaunch_file, use_test_depends=False, ignore_default_args=False):
     print("checking", roslaunch_file)
-    error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file, use_test_depends=use_test_depends)
+    error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file, use_test_depends=use_test_depends, ignore_default_args=ignore_default_args)
     # error message has to be XML attr safe
     if error_msg:
-        # #953 option to implement ignore default arg errors
-        if ignore_default_args:
-            import re
-            if re.compile('requires the \'.*\' arg to be set').search(error_msg):
-                return None
         return "[%s]:\n\t%s"%(roslaunch_file,error_msg)
 
 def check_roslaunch_dir(roslaunch_dir, use_test_depends=False, ignore_default_args=False):

--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -41,20 +41,25 @@ import rospkg
 import roslaunch.rlutil
 import rosunit
 
-def check_roslaunch_file(roslaunch_file, use_test_depends=False):
+def check_roslaunch_file(roslaunch_file, use_test_depends=False, ignore_default_args=False):
     print("checking", roslaunch_file)
     error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file, use_test_depends=use_test_depends)
     # error message has to be XML attr safe
     if error_msg:
+        # #953 option to implement ignore default arg errors
+        if ignore_default_args:
+            import re
+            if re.compile('requires the \'.*\' arg to be set').search(error_msg):
+                return None
         return "[%s]:\n\t%s"%(roslaunch_file,error_msg)
 
-def check_roslaunch_dir(roslaunch_dir, use_test_depends=False):
+def check_roslaunch_dir(roslaunch_dir, use_test_depends=False, ignore_default_args=False):
     error_msgs = []
     for f in os.listdir(roslaunch_dir):
         if f.endswith('.launch'):
             roslaunch_file = os.path.join(roslaunch_dir, f)
             if os.path.isfile(roslaunch_file):
-                error_msgs.append(check_roslaunch_file(roslaunch_file, use_test_depends=use_test_depends))
+                error_msgs.append(check_roslaunch_file(roslaunch_file, use_test_depends=use_test_depends, ignore_default_args=ignore_default_args))
     # error message has to be XML attr safe
     return '\n'.join([e for e in error_msgs if e])
 
@@ -69,6 +74,9 @@ if __name__ == '__main__':
     parser.add_option("-t", "--use-test-depends",
                       action="store_true", dest="test_depends", default=False,
                       help="Assuming packages listed in test_depends are also installed")
+    parser.add_option("--ignore-default-args",
+                      action="store_true", dest="ignore_default_args", default=False,
+                      help="Ignore check for default value of <arg> parameters")
 
     options, args = parser.parse_args()
     if not args:
@@ -86,10 +94,10 @@ if __name__ == '__main__':
     pkg_dir = r.get_path(pkg)
 
     if os.path.isfile(roslaunch_path):
-        error_msg = check_roslaunch_file(roslaunch_path, use_test_depends=options.test_depends)
+        error_msg = check_roslaunch_file(roslaunch_path, use_test_depends=options.test_depends, ignore_default_args=options.ignore_default_args)
     else:
         print("checking *.launch in directory", roslaunch_path)
-        error_msg = check_roslaunch_dir(roslaunch_path, use_test_depends=options.test_depends)
+        error_msg = check_roslaunch_dir(roslaunch_path, use_test_depends=options.test_depends, ignore_default_args=options.ignore_default_args)
     relpath = os.path.abspath(roslaunch_path)[len(os.path.abspath(pkg_dir))+1:]
     outname = relpath.replace('.', '_').replace(os.sep, '_')
     if outname == '_':

--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -407,7 +407,7 @@ class ROSLaunchConfig(object):
             # assign to local machine
             return self.machines['']            
 
-def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None, verbose=False, assign_machines=True):
+def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None, verbose=False, assign_machines=True, ignore_default_args=False):
     """
     Base routine for creating a ROSLaunchConfig from a set of 
     roslaunch_files and or launch XML strings and initializing it. This
@@ -423,6 +423,8 @@ def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None,
     @type  verbose: bool
     @param assign_machines: (optional) assign nodes to machines (default: True)
     @type  assign_machines: bool
+    @param ignore_default_args: (optional) ignore default arg requirements (default: False)
+    @type ignore_default_args: bool
     @return: initialized rosconfig instance
     @rytpe: L{ROSLaunchConfig} initialized rosconfig instance
     @raises: RLException
@@ -438,6 +440,7 @@ def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None,
         config.master.uri = rosgraph.network.create_local_xmlrpc_uri(port)
 
     loader = loader or roslaunch.xmlloader.XmlLoader()
+    loader.ignore_default_args = ignore_default_args
 
     # load the roscore file first. we currently have
     # last-declaration wins rules.  roscore is just a

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -326,8 +326,11 @@ def roslaunch_deps(files, verbose=False, use_test_depends=False, ignore_default_
         try:
             rl_file_deps(file_deps, launch_file, verbose)
         except RoslaunchDepsException as e:
-            import re
-            if not re.compile(r'No value for arg').search(str(e)):
+            if ignore_default_args:
+                import re
+                if not re.compile(r'No value for arg').search(str(e)):
+                    raise RoslaunchDepsException(str(e))
+            else:
                 raise RoslaunchDepsException(str(e))
 
     calculate_missing(base_pkg, missing, file_deps, use_test_depends=use_test_depends)

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -289,9 +289,9 @@ def calculate_missing(base_pkg, missing, file_deps, use_test_depends=False):
             missing[pkg] = set()
         missing[pkg].update(diff)
     return missing
-        
-    
-def roslaunch_deps(files, verbose=False, use_test_depends=False):
+
+
+def roslaunch_deps(files, verbose=False, use_test_depends=False, ignore_default_args=False):
     """
     @param packages: list of packages to check
     @type  packages: [str]
@@ -300,6 +300,8 @@ def roslaunch_deps(files, verbose=False, use_test_depends=False):
     @type  files: [str]
     @param use_test_depends [bool]: use test_depends as installed package
     @type  use_test_depends: [bool]
+    @param ignore_default_args [bool]: ignore exceptions raised by missing default value for <arg> tags
+    @type  ignore_default_args: [bool]
     @return: base_pkg, file_deps, missing.
       base_pkg is the package of all files
       file_deps is a { filename : RoslaunchDeps } dictionary of
@@ -321,7 +323,12 @@ def roslaunch_deps(files, verbose=False, use_test_depends=False):
         if base_pkg and pkg != base_pkg:
             raise RoslaunchDepsException("roslaunch files must be in the same package: %s vs. %s"%(base_pkg, pkg))
         base_pkg = pkg
-        rl_file_deps(file_deps, launch_file, verbose)
+        try:
+            rl_file_deps(file_deps, launch_file, verbose)
+        except RoslaunchDepsException as e:
+            import re
+            if not re.compile(r'No value for arg').search(str(e)):
+                raise RoslaunchDepsException(str(e))
 
     calculate_missing(base_pkg, missing, file_deps, use_test_depends=use_test_depends)
     return base_pkg, file_deps, missing            

--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -179,18 +179,19 @@ def get_or_generate_uuid(options_runid, options_wait_for_master):
             if not options_wait_for_master:
                 val = roslaunch.core.generate_run_id()
     return val
-    
-def check_roslaunch(f, use_test_depends=False):
+
+def check_roslaunch(f, use_test_depends=False, ignore_default_args=False):
     """
     Check roslaunch file for errors, returning error message if check fails. This routine
     is mainly to support rostest's roslaunch_check.
 
     :param f: roslaunch file name, ``str``
     :param use_test_depends: Consider test_depends, ``Bool``
+    :param ignore_default_args: Consider ignore default arg requirements, ``Bool``
     :returns: error message or ``None``
     """
     try:
-        rl_config = roslaunch.config.load_config_default([f], DEFAULT_MASTER_PORT, verbose=False)
+        rl_config = roslaunch.config.load_config_default([f], DEFAULT_MASTER_PORT, verbose=False, ignore_default_args=ignore_default_args)
     except roslaunch.core.RLException as e:
         return str(e)
     
@@ -198,7 +199,7 @@ def check_roslaunch(f, use_test_depends=False):
     errors = []
     # check for missing deps
     try:
-        base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f], use_test_depends=use_test_depends)
+        base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f], use_test_depends=use_test_depends, ignore_default_args=ignore_default_args)
     except rospkg.common.ResourceNotFound as r:
         errors.append("Could not find package [%s] included from [%s]"%(str(r), f))
         missing = {}

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -629,7 +629,8 @@ class XmlLoader(loader.Loader):
             loader.post_process_include_args(child_ns)
 
         except ArgException as e:
-            raise XmlParseException("included file [%s] requires the '%s' arg to be set"%(inc_filename, str(e)))
+            if not self.ignore_default_args:
+                raise XmlParseException("included file [%s] requires the '%s' arg to be set"%(inc_filename, str(e)))
         except XmlParseException as e:
             raise XmlParseException("while processing %s:\n%s"%(inc_filename, str(e)))
         if verbose:
@@ -747,7 +748,8 @@ class XmlLoader(loader.Loader):
             ros_config.add_roslaunch_file(filename)            
             self._load_launch(launch, ros_config, is_core=core, filename=filename, argv=argv, verbose=verbose)
         except ArgException as e:
-            raise XmlParseException("[%s] requires the '%s' arg to be set"%(filename, str(e)))
+            if not self.ignore_default_args:
+                raise XmlParseException("[%s] requires the '%s' arg to be set"%(filename, str(e)))
         except SubstitutionException as e:
             raise XmlParseException(str(e))
 

--- a/tools/roslaunch/test/unit/test_roslaunch_rlutil.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_rlutil.py
@@ -84,4 +84,13 @@ class TestRoslaunchRlutil(unittest.TestCase):
                 self.fail("should have failed")
             except roslaunch.RLException:
                 pass
-            
+
+    def test_check_roslaunch(self):
+        from roslaunch.rlutil import check_roslaunch
+
+        test_ignore_default_args_p = os.path.join(get_test_path(), 'test', 'xml', 'test-ignore-default-args.launch')
+        try:
+            result = check_roslaunch(test_ignore_default_args_p, ignore_default_args=True)
+            self.assertEqual(result, None)
+        except roslaunch.RLException:
+            pass

--- a/tools/roslaunch/test/xml/test-ignore-default-args.launch
+++ b/tools/roslaunch/test/xml/test-ignore-default-args.launch
@@ -1,0 +1,6 @@
+<launch>
+  <arg name="foo" />    <!-- no `default="something" here! -->
+  <node name="bar" pkg="bar" type="bar">
+    <param name="foo" value="$(arg foo)" />
+  </node>
+</launch>


### PR DESCRIPTION
See https://github.com/ros/ros_comm/issues/953

Adds an option to roslaunch-check to ignore the error thrown when a `<arg>` is declared but doesn't have a default variable.

### Usage

From the roslaunch-check script: `rosrun roslaunch roslaunch-check [-i / --ignore-default-args] foo.launch`
From a CMakeLists.txt file: `roslaunch_add_file_check(launch/foo.launch IGNORE_DEFAULT_ARGS)`

### Example
The example given in https://github.com/ros/ros_comm/issues/953 is as follows:
```
<launch>
  <arg name="foo" />    <!-- no `default="something" here! --> 
  <node name="bar" pkg="bar" type="bar">
    <param name="foo" value="$(arg foo)" />
  </node>
</launch>
```

which, when run with roslaunch-check, will output 
```
$ rosrun roslaunch roslaunch-check foo.launch
FAILURE:
[foo.launch]:
	[foo.launch] requires the 'foo' arg to be set
```

The change adds an option to ignore this error with `-i` or `--ignore-default-args` like so
```
$ rosrun roslaunch roslaunch-check --ignore-default-args foo.launch
passed
```